### PR TITLE
Integrate Firebase Crashlytics (startup handlers + Android Gradle plugin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,19 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Firebase Crashlytics setup
+
+Crashlytics has been wired into the Flutter app and Android Gradle plugins.
+To complete production setup, run the following once in your environment:
+
+1. Update Firebase app registration so IDs match this project:
+   - Android `applicationId`: `jp.co.haruki.hmlm`
+   - iOS `PRODUCT_BUNDLE_IDENTIFIER`: `com.example.hmlm.fh`
+2. Download and replace:
+   - `android/app/google-services.json`
+   - `ios/Runner/GoogleService-Info.plist`
+3. Run `flutterfire configure` to regenerate `lib/firebase_options.dart`.
+4. Build release artifacts once so Crashlytics can process symbols.
+
+The app now sends fatal Flutter and platform errors to Crashlytics at startup.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id "com.android.application"
     // START: FlutterFire Configuration
     id "com.google.gms.google-services"
+    id "com.google.firebase.crashlytics"
     // END: FlutterFire Configuration
     id "kotlin-android"
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -21,6 +21,7 @@ plugins {
     id "com.android.application" version "8.8.1" apply false
     // START: FlutterFire Configuration
     id "com.google.gms.google-services" version "4.3.15" apply false
+    id "com.google.firebase.crashlytics" version "3.0.3" apply false
     // END: FlutterFire Configuration
     id "org.jetbrains.kotlin.android" version "1.8.22" apply false
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,10 @@
+import 'dart:ui'; // ← グローバルエラーハンドラ（PlatformDispatcher）で使用
 import 'package:flutter/material.dart'; // ← Flutterの基本UIライブラリをインポート
 import 'package:googlemap_api/screens/map_screen/map_screen.dart'; // ← アプリのメイン画面（MapScreen）をインポート
 import 'package:googlemap_api/firebase_options.dart'; // ← Firebaseの設定情報をインポート
 import 'package:firebase_core/firebase_core.dart'; // ← Firebase初期化に必要なパッケージをインポート
 import 'package:firebase_auth/firebase_auth.dart'; // ← Firebase認証の状態（ログイン済みか）を確認するために使用
+import 'package:firebase_crashlytics/firebase_crashlytics.dart'; // ← Crashlyticsエラーレポート送信用
 import 'package:googlemap_api/screens/map_screen/prelogin_screen.dart'; // ← ログイン前に見せる画面
 
 Future<void> main() async { // ← アプリのエントリーポイント（非同期関数）
@@ -10,6 +12,16 @@ Future<void> main() async { // ← アプリのエントリーポイント（非
   await Firebase.initializeApp( // ← Firebaseを初期化
     options: DefaultFirebaseOptions.currentPlatform, // ← 現在のプラットフォーム用のFirebase設定を読み込む
   );
+
+  // Flutterフレームワーク起因の致命的エラーをCrashlyticsへ送信
+  FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterFatalError;
+
+  // 非同期ゾーン外の致命的エラーをCrashlyticsへ送信
+  PlatformDispatcher.instance.onError = (error, stack) {
+    FirebaseCrashlytics.instance.recordError(error, stack, fatal: true);
+    return true;
+  };
+
   runApp(const MyApp()); // ← MyAppウィジェットをアプリとして実行
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   cloud_firestore: ^5.6.4
   image_picker: ^1.1.2
   firebase_storage: ^12.4.7
+  firebase_crashlytics: ^4.3.3
   flutter_launcher_icons: ^0.14.3
   flutter_native_splash: ^2.4.6
 


### PR DESCRIPTION
### Motivation
- Capture and report fatal runtime errors from both the Flutter framework and platform-level (unhandled) errors using Firebase Crashlytics. 
- Enable Crashlytics support in the Android build so crash reporting and symbol upload can be performed for release builds.

### Description
- Added the `firebase_crashlytics` dependency to `pubspec.yaml` so the SDK is available to the app. 
- Enabled the Crashlytics Gradle plugin in `android/settings.gradle` and `android/app/build.gradle` to activate Crashlytics for the Android project. 
- Wired startup error handlers in `lib/main.dart` by importing `package:firebase_crashlytics/firebase_crashlytics.dart` and setting `FlutterError.onError` and `PlatformDispatcher.instance.onError` to forward fatal errors to Crashlytics. 
- Appended a `README.md` section with setup steps describing required Firebase config files and `flutterfire configure` to complete the integration.

### Testing
- Verified the presence of Crashlytics changes by running `rg -n "firebase_crashlytics|crashlytics"` against the modified files, which located the new entries. 
- Attempted `flutter pub get` in this environment but it failed because the `flutter` CLI is not available in the PATH. 
- No automated unit/integration tests were executed in this environment; recommend running `flutter pub get`, `flutterfire configure`, and building release artifacts locally to validate end-to-end Crashlytics behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c4d9f47ec83279efc13b941cd6aa8)