### PR TITLE
Replace hardcoded API keys with placeholders and add secrets management

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,17 @@ To complete production setup, run the following once in your environment:
 4. Build release artifacts once so Crashlytics can process symbols.
 
 The app now sends fatal Flutter and platform errors to Crashlytics at startup.
+
+## Secrets management
+
+This repository intentionally uses placeholder values for API keys.
+
+- Android Google Maps key:
+  1. Copy `android/secret.properties.example` to `android/secret.properties`.
+  2. Set `googleMap.apiKey` in `android/secret.properties`.
+- iOS Google Maps key:
+  1. Set `GOOGLE_MAPS_API_KEY` in `ios/Runner/Info.plist` for local development.
+  2. In CI/release builds, inject `GOOGLE_MAPS_API_KEY` from secret build settings.
+- Firebase config files (`google-services.json`, `GoogleService-Info.plist`, and `lib/firebase_options.dart`) must be replaced with project-specific values generated from your Firebase project.
+
+Never commit real API keys or production secrets.

--- a/android/.gitignore
+++ b/android/.gitignore
@@ -13,3 +13,4 @@ key.properties
 **/*.jks
 
 secret.properties
+sercret.properties

--- a/android/app/google-services.json
+++ b/android/app/google-services.json
@@ -15,7 +15,7 @@
       "oauth_client": [],
       "api_key": [
         {
-          "current_key": "AIzaSyBPGcMQDzWMW7wpTG6gv06bwkXvUNthUxk"
+          "current_key": "FIREBASE_ANDROID_API_KEY"
         }
       ],
       "services": {

--- a/android/secret.properties.example
+++ b/android/secret.properties.example
@@ -1,0 +1,3 @@
+# Copy this file to android/secret.properties and set your own key.
+# Never commit real API keys.
+googleMap.apiKey=YOUR_GOOGLE_MAPS_API_KEY

--- a/android/sercret.properties
+++ b/android/sercret.properties
@@ -1,1 +1,0 @@
-googleMap.apiKey=<AIzaSyC3RWO2c5uUTg_BbvCs4CsXW1dXzVSVe7o>

--- a/ios/Runner/Env.swift
+++ b/ios/Runner/Env.swift
@@ -1,5 +1,12 @@
 import Foundation
 
 struct Env {
-    static let googleMapApiKey = "AIzaSyC3RWO2c5uUTg_BbvCs4CsXW1dXzVSVe7o"
+    static var googleMapApiKey: String {
+        guard let key = Bundle.main.object(forInfoDictionaryKey: "GOOGLE_MAPS_API_KEY") as? String,
+              !key.isEmpty,
+              key != "YOUR_GOOGLE_MAPS_API_KEY" else {
+            fatalError("GOOGLE_MAPS_API_KEY is not configured. Set it in ios/Runner/Info.plist for local dev or via build settings in CI.")
+        }
+        return key
+    }
 }

--- a/ios/Runner/GoogleService-Info.plist
+++ b/ios/Runner/GoogleService-Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>API_KEY</key>
-	<string>AIzaSyCMuI-gSoXNiKzKq0sgtt2qxPdW6YV2drc</string>
+	<string>FIREBASE_IOS_API_KEY</string>
 	<key>GCM_SENDER_ID</key>
 	<string>281104655266</string>
 	<key>PLIST_VERSION</key>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -16,7 +16,9 @@
 		<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 		<key>CFBundleInfoDictionaryVersion</key>
 		<string>6.0</string>
-		<key>CFBundleName</key>
+		<key>GOOGLE_MAPS_API_KEY</key>
+	<string>YOUR_GOOGLE_MAPS_API_KEY</string>
+	<key>CFBundleName</key>
 		<string>googlemap_api</string>
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>

--- a/lib/firebase_options.dart
+++ b/lib/firebase_options.dart
@@ -51,7 +51,7 @@ class DefaultFirebaseOptions { // ← Firebase 各プラットフォームの設
   }
 
   static const FirebaseOptions android = FirebaseOptions( // ← Android 用の Firebase 設定を定義
-    apiKey: 'AIzaSyBPGcMQDzWMW7wpTG6gv06bwkXvUNthUxk', // ← Firebase プロジェクトのAPIキー
+    apiKey: 'FIREBASE_ANDROID_API_KEY', // ← Firebase プロジェクトのAPIキー
     appId: '1:281104655266:android:087ada22f30aeaa07748fb', // ← FirebaseアプリのID
     messagingSenderId: '281104655266', // ← Firebase Cloud Messagingの送信者ID
     projectId: 'api-app-cc4de', // ← FirebaseプロジェクトID
@@ -59,7 +59,7 @@ class DefaultFirebaseOptions { // ← Firebase 各プラットフォームの設
   );
 
   static const FirebaseOptions ios = FirebaseOptions( // ← iOS 用の Firebase 設定を定義
-    apiKey: 'AIzaSyCMuI-gSoXNiKzKq0sgtt2qxPdW6YV2drc', // ← FirebaseプロジェクトのAPIキー（iOS用）
+    apiKey: 'FIREBASE_IOS_API_KEY', // ← FirebaseプロジェクトのAPIキー（iOS用）
     appId: '1:281104655266:ios:c6da651f1478150e7748fb', // ← FirebaseアプリのID（iOS）
     messagingSenderId: '281104655266', // ← Firebase Cloud Messagingの送信者ID
     projectId: 'api-app-cc4de', // ← FirebaseプロジェクトID


### PR DESCRIPTION
### Motivation

- Remove committed production API keys from the repository and centralize instructions for secure secret handling.
- Prevent accidental builds from using embedded keys by providing placeholder values and fail-fast checks for missing configuration.

### Description

- Add a `Secrets management` section to `README.md` with instructions to use `android/secret.properties` and to inject `GOOGLE_MAPS_API_KEY` for iOS, and warnings to never commit real keys.
- Replace embedded Firebase API keys with placeholders in `lib/firebase_options.dart`, `android/app/google-services.json`, and `ios/Runner/GoogleService-Info.plist` using `FIREBASE_ANDROID_API_KEY` and `FIREBASE_IOS_API_KEY` placeholders.
- Introduce `android/secret.properties.example` and remove the committed `android/sercret.properties` file, and update `android/.gitignore` to ignore `secret.properties` (removing the committed secret file from source tracking).
- Add `GOOGLE_MAPS_API_KEY` placeholder to `ios/Runner/Info.plist` and update `ios/Runner/Env.swift` to read `GOOGLE_MAPS_API_KEY` from the app `Bundle` and `fatalError` if it is not configured to ensure explicit configuration during local development and CI.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6dfc366648327a2a48f30949304a2)