### PR TITLE
Throttle map camera auto-follow to once every 5 minutes

### DIFF
--- a/lib/screens/map_screen/map_screen.dart
+++ b/lib/screens/map_screen/map_screen.dart
@@ -59,6 +59,10 @@ class _MapScreenState extends State<MapScreen> {
     distanceFilter: 20, // 20m移動でイベント発火
   );
 
+  // ------------  Camera follow control  ------------
+  static const Duration _cameraFollowInterval = Duration(minutes: 5);
+  DateTime? _lastCameraFollowAt;
+
   // ------------  Auth  ------------
   late StreamSubscription<User?> authUserStream; // 認証状態リスナー
   String currentUserId = ''; // 現在ログイン中のuid
@@ -580,7 +584,9 @@ class _MapScreenState extends State<MapScreen> {
   }
 
   void _watchCurrentLocation() {
-    // 位置更新ストリーム購読→Firestore更新・カメラ追従のみ
+    // 位置更新ストリーム購読→Firestore更新。
+    // カメラ追従は「5分に1回まで」に制限して、
+    // ユーザーの手動操作中に勝手に戻り続ける挙動を防ぐ。
     positionStream =
         Geolocator.getPositionStream(locationSettings: locationSettings)
             .listen((position) async {
@@ -590,14 +596,22 @@ class _MapScreenState extends State<MapScreen> {
 
           await _updateUserLocationInFirestore(position);
 
-          await mapController.animateCamera(
-            CameraUpdate.newCameraPosition(
-              CameraPosition(
-                target: LatLng(position.latitude, position.longitude),
-                zoom: await mapController.getZoomLevel(),
+          final now = DateTime.now();
+          final canAutoFollow =
+              _lastCameraFollowAt == null ||
+              now.difference(_lastCameraFollowAt!) >= _cameraFollowInterval;
+
+          if (canAutoFollow) {
+            await mapController.animateCamera(
+              CameraUpdate.newCameraPosition(
+                CameraPosition(
+                  target: LatLng(position.latitude, position.longitude),
+                  zoom: await mapController.getZoomLevel(),
+                ),
               ),
-            ),
-          );
+            );
+            _lastCameraFollowAt = now;
+          }
         });
   }
 


### PR DESCRIPTION
### Motivation
- Prevent the map camera from continuously snapping back to the user's location during frequent position updates and while the user is interacting with the map.

### Description
- Add `static const Duration _cameraFollowInterval = Duration(minutes: 5);` and `DateTime? _lastCameraFollowAt;` to track and limit automatic camera follows.
- Update `_watchCurrentLocation` to only call `mapController.animateCamera` when the last auto-follow occurred more than `_cameraFollowInterval` ago, while still updating Firestore with the latest position.
- Clarify inline comments about limiting camera follow to avoid disrupting user manual map interactions.

### Testing
- Ran `flutter analyze` with no new analyzer errors reported.
- Ran `flutter test` and all existing tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad7227251483278e8b3476f249f99c)